### PR TITLE
README updates, .env.example comments, add `get_` prefix to a model m…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
+# Environment variables for appointment-reminders-flask
+
+# App settings
 DATABASE_URL=postgres://someuser:withsomepassword@localhost:5432/appointments
 SECRET_KEY=asupersecr3tkeyshouldgo
 CELERY_URL=redis://localhost:6379
+
+# Twilio settings
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_NUMBER=

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Twilio Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/models/appointment.py
+++ b/models/appointment.py
@@ -25,7 +25,7 @@ class Appointment(Base):
     def __repr__(self):
         return '<Appointment %r>' % self.name
 
-    def notification_time(self):
+    def get_notification_time(self):
         appointment_time = arrow.get(self.time)
         reminder_time = appointment_time.replace(minutes=-self.delta)
         return reminder_time

--- a/readme.md
+++ b/readme.md
@@ -11,19 +11,17 @@ dashboard. Otherwise the app won't be able to send SMS.
 
 ## Installing dependencies
 
+This app runs on Python 2.7, 3.3, and 3.4.
+
 It is recommended to use a [virtualenv](https://virtualenv.pypa.io/en/latest/)
 together with
 [virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/) to
 manage the applications' dependencies. Assuming both are installed, the
 application can be run as follows:
 
-Create a virtualenv with virtualenvwrapper:
+Create a virtualenv with virtualenvwrapper (using Python 3):
 ```
 mkvirtualenv appointment-reminders-flask --python python3
-```
-Activate the virtualenv:
-```
-workon appointment-reminders-flask
 ```
 Inside the cloned repo you can install the dependencies of the
 application using:
@@ -31,24 +29,29 @@ application using:
 pip install -r requirements.txt
 ```
 ## Database migrations
-You'll need to set the environment variables specified in env.example
-to match your local configuration. Either set the variables manually
-or source the file. The database schema is managed using
-[Alembic](https://github.com/zzzeek/alembic).
+
+First, make sure [Postgres](http://www.postgresql.org/) is running on your system.
+
+You'll need to set the environment variables specified in `.env.example`
+to match your local configuration and `source` that file, or set the
+environment variables manually.
+
+The database schema is managed using [Alembic](https://github.com/zzzeek/alembic).
 
 Migrate the database:
 ```
 alembic upgrade +1
 ```
 ## Start the celery worker
-First you'll need to have a backend running. In this case we're going
-to use [Redis](http://redis.io/). Simply execute `redis-server` to
-run the server.
+First you'll need to have a
+[message broker](http://celery.readthedocs.org/en/latest/getting-started/brokers/)
+running. In this case we're going to use [Redis](http://redis.io/). Once
+installed, simply execute `redis-server` to run the server.
 
-To start the celery worker we need to point out the module that exports
-the celery app object.
+To start the celery worker we need to use the `celery`
+command with the module that exports the celery app object.
 ```
-celery -A reminders.celery worker
+celery -A reminders.celery worker -l info
 ```
 ## Running the application
 
@@ -57,7 +60,7 @@ The application can be run with:
 ```
 python runapp.py
 ```
-If all environment variables specified in `env.example` are set
+If all environment variables specified in `.env.example` are set
 correctly then the application is now ready to send SMS
 reminders. Open
 [http://localhost:5000/appointment/new](http://localhost:5000/appointment/new)
@@ -66,8 +69,8 @@ to create a new appointment.
 ## Run the tests
 Assuming you have configured the application for your local test
 environment, you can then use Alembic to migrate the test database
-(by setting the correct `DATABASE_URL`) and then use pytest
+(by setting the correct `DATABASE_URL`) and then use [pytest](http://pytest.org/)
 to run the tests:
 ```
-py.test
+py.test --cov .
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ psycopg2==2.6.1
 py==1.4.30
 PySocks==1.5.4
 pytest==2.7.2
+pytest-cov==2.0.0
 pytest-pythonpath==0.7
 python-dateutil==2.4.2
 pytz==2015.4

--- a/views/appointment.py
+++ b/views/appointment.py
@@ -31,7 +31,7 @@ class AppointmentResourceCreateIndex(MethodView):
             reminders.db.session.add(appt)
             reminders.db.session.commit()
             send_sms_reminder.apply_async(
-                args=[appt.id], eta=appt.notification_time())
+                args=[appt.id], eta=appt.get_notification_time())
 
             return redirect(url_for('appointment.index'), code=303)
         else:


### PR DESCRIPTION
Hi guys -

Overall I thought this app looked solid. I just made a few changes that I think should be merged in:

- Adding a few links to the README
- Adding a Twilio copyright MIT license
- Adding pytest-cov and updating the tests section of the README to run with coverage
- Changing `notification_time` on the `Appointment` model to be named `get_notification_time`

I'm going to create a couple issues on the repo for some other things I think you should look at.